### PR TITLE
Removing clang builds, since clange only has partial support for jthread

### DIFF
--- a/.github/workflows/build_run_unit_test_cmake.yml
+++ b/.github/workflows/build_run_unit_test_cmake.yml
@@ -12,8 +12,8 @@ jobs:
   build_matrix:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14]
-        # os: [ubuntu-latest]
+        # os: [ubuntu-latest, windows-latest, macos-14]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `wait-queue` header file does not have any third-party dependencies. It uses
 
 ## Supported Compilers
 
-Continuous integration workflows build and unit test on g++ (through Ubuntu), MSVC (through Windows), and clang (through macOS).
+Continuous integration workflows build and unit test on g++ (through Ubuntu) and MSVC (through Windows). Note that clang support for C++ 20 `std::jthread` and `std::stop_token` is still incomplete as of May 2024.
 
 ## Unit Test Dependencies
 


### PR DESCRIPTION
Tweaks to workflow file and README